### PR TITLE
refactor: rename autocorrect to autoCorrect

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "turbo run lint",
     "format": "turbo run format"
   },
-  "repository": "https://github.com/lastfm-ts/lastfm-ts",
+  "repository": "https://github.com/lastfm4devs/lastfm-ts",
   "author": "Davi Patricio <davipatricio@protonmail.com>",
   "license": "MIT",
   "devDependencies": {

--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -24,7 +24,7 @@
     "types",
     "typings"
   ],
-  "repository": "https://github.com/lastfm-ts/lastfm-ts",
+  "repository": "https://github.com/lastfm4devs/lastfm-ts",
   "author": "Davi Patricio <davipatricio@protonmail.com>",
   "license": "MIT",
   "devDependencies": {

--- a/packages/api-wrapper/package.json
+++ b/packages/api-wrapper/package.json
@@ -23,8 +23,8 @@
     "lastfm-api",
     "api-wrapper"
   ],
+  "repository": "https://github.com/lastfm4devs/lastfm-ts",
   "author": "Davi Patricio <davipatricio@protonmail.com>",
-  "repository": "https://github.com/lastfm-ts/lastfm-ts",
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^20.6.2",

--- a/packages/api-wrapper/src/client/managers/ArtistManager.ts
+++ b/packages/api-wrapper/src/client/managers/ArtistManager.ts
@@ -10,7 +10,7 @@ interface ArtistGetOptions {
   /**
    * Whether to autocorrect the query
    */
-  autocorrect?: boolean;
+  autoCorrect?: boolean;
   /**
    * Whether to search for the artist if it is not found
    */
@@ -24,7 +24,7 @@ interface ArtistSimilarOptions {
   /**
    * Whether to autocorrect the query
    */
-  autocorrect?: boolean;
+  autoCorrect?: boolean;
   /**
    * The limit of results to return
    */
@@ -64,12 +64,12 @@ export class ArtistManager {
     artist: string,
     options: ArtistGetOptions & { searchIfNotFound: true },
   ): Promise<Artist | PartialArtist>;
-  public async get(artist: string,options?: ArtistGetOptions): Promise<Artist>;
+  public async get(artist: string, options?: ArtistGetOptions): Promise<Artist>;
   public async get(artist: string, options: ArtistGetOptions = {}) {
     try {
       const res = await this.client.rest.request<APIGetArtistInfo>('GET', 'artist.getinfo', {
         artist,
-        autocorrect: options.autocorrect ? 1 : 0,
+        autocorrect: options.autoCorrect ? 1 : 0,
       });
 
       return new Artist(res.artist);
@@ -99,7 +99,7 @@ export class ArtistManager {
   public async getSimilar(artist: string, options: ArtistSimilarOptions = {}) {
     const res = await this.client.rest.request<APIGetSimilarArtist>('GET', 'artist.getsimilar', {
       artist,
-      autocorrect: options.autocorrect ? 1 : 0,
+      autocorrect: options.autoCorrect ? 1 : 0,
       limit: options.limit ?? 30,
     });
 

--- a/packages/api-wrapper/src/client/managers/TrackManager.ts
+++ b/packages/api-wrapper/src/client/managers/TrackManager.ts
@@ -10,7 +10,7 @@ interface TrackGetOptions {
   /**
    * Whether to autocorrect the query
    */
-  autocorrect?: boolean;
+  autoCorrect?: boolean;
   /**
    * Whether to search for the track if it is not found
    */
@@ -24,7 +24,7 @@ interface TrackSimilarOptions {
   /**
    * Whether to autocorrect the query
    */
-  autocorrect?: boolean;
+  autoCorrect?: boolean;
   /**
    * The limit of results to return
    */
@@ -78,7 +78,7 @@ export class TrackManager {
       const res = await this.client.rest.request<APIGetTrackInfo>('GET', 'track.getinfo', {
         artist,
         track,
-        autocorrect: options.autocorrect ? 1 : 0,
+        autocorrect: options.autoCorrect ? 1 : 0,
       });
 
       return new Track(res.track);
@@ -110,7 +110,7 @@ export class TrackManager {
     const res = await this.client.rest.request<APIGetSimilarTrack>('GET', 'track.getsimilar', {
       artist,
       track,
-      autocorrect: options.autocorrect ? 1 : 0,
+      autocorrect: options.autoCorrect ? 1 : 0,
       limit: options.limit ?? 30,
     });
 

--- a/packages/api-wrapper/src/structures/index.ts
+++ b/packages/api-wrapper/src/structures/index.ts
@@ -5,4 +5,3 @@ export * from './PartialAlbum';
 export * from './PartialArtist';
 export * from './PartialTrack';
 export * from './Track';
-


### PR DESCRIPTION
- Updated the repository link in package.json
- Renamed `autocorrect` to `autoCorrect`, to follow the Camel Case pattern

I tested these patches on my machine and seems like it all works great!